### PR TITLE
Handle Infinity connection pool in Gunicorn workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ RAGFlow uses Elasticsearch by default for storing full text and vectors. To swit
    $ docker compose -f docker-compose.yml up -d
    ```
 
+> **Note** When running RAGFlow with Gunicorn and Infinity, each worker must reinitialize its connection pool. The provided `conf/gunicorn.conf.py` handles this in `post_fork`.
+
 > [!WARNING]
 > Switching to Infinity on a Linux/arm64 machine is not yet officially supported.
 
@@ -346,7 +348,7 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
    # centos
    sudo yum install jemalloc
    ```
-   
+
 6. Launch backend service:
 
    ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -273,6 +273,8 @@ RAGFlow 默认使用 Elasticsearch 存储文本和向量数据. 如果要切换�
    $ docker compose -f docker-compose.yml up -d
    ```
 
+> **注意**：在使用 Gunicorn 且文档引擎为 Infinity 时，需要在 `post_fork` 阶段为每个 worker 重新初始化连接池。`conf/gunicorn.conf.py` 已包含该逻辑。
+
 > [!WARNING]
 > Infinity 目前官方并未正式支持在 Linux/arm64 架构下的机器上运行.
 

--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -2,13 +2,18 @@
 import multiprocessing
 import os
 
+from api import settings
+from rag.nlp import search
+from graphrag import search as kg_search
+from rag.utils.infinity_conn import InfinityConnection
+
 # Server socket
 bind = f"{os.environ.get('RAGFLOW_HOST_IP', '0.0.0.0')}:{os.environ.get('RAGFLOW_HOST_PORT', '9380')}"
 backlog = 2048
 
 # Worker processes
-workers = int(os.environ.get('GUNICORN_WORKERS', min(multiprocessing.cpu_count() * 2 + 1, 8)))
-worker_class = 'gevent'
+workers = int(os.environ.get("GUNICORN_WORKERS", min(multiprocessing.cpu_count() * 2 + 1, 8)))
+worker_class = "gevent"
 
 # Gevent-specific settings
 worker_connections = 1000
@@ -20,17 +25,17 @@ max_requests_jitter = 200
 preload_app = True
 
 # Logging
-accesslog = '-'
-errorlog = '-'
-loglevel = 'debug'
+accesslog = "-"
+errorlog = "-"
+loglevel = "debug"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
 
 # Process naming
-proc_name = 'ragflow_gunicorn'
+proc_name = "ragflow_gunicorn"
 
 # Server mechanics
 daemon = False
-pidfile = '/tmp/ragflow_gunicorn.pid'
+pidfile = "/tmp/ragflow_gunicorn.pid"
 tmp_upload_dir = None
 
 # Security
@@ -39,7 +44,7 @@ limit_request_fields = 200
 limit_request_field_size = 8190
 
 # Performance tuning for RAGFlow
-worker_tmp_dir = '/dev/shm'  # Use memory for temporary files if available
+worker_tmp_dir = "/dev/shm"  # Use memory for temporary files if available
 
 # SSL (if needed)
 # keyfile = None
@@ -47,33 +52,38 @@ worker_tmp_dir = '/dev/shm'  # Use memory for temporary files if available
 
 # Environment variables that gunicorn should pass to workers
 raw_env = [
-    'PYTHONPATH=/ragflow/',
+    "PYTHONPATH=/ragflow/",
 ]
+
 
 def when_ready(server):
     """Called just after the server is started."""
     server.log.info("RAGFlow Gunicor n server is ready. Production mode active.")
 
+
 def worker_int(worker):
     """Called just after a worker exited on SIGINT or SIGQUIT."""
     worker.log.info("RAGFlow worker received INT or QUIT signal")
+
 
 def pre_fork(server, worker):
     """Called just before a worker is forked."""
     server.log.info("RAGFlow worker about to be forked")
 
+
 def post_fork(server, worker):
     """Called just after a worker has been forked."""
     server.log.info("RAGFlow worker spawned (pid: %s)", worker.pid)
-    
-    # 重新初始化InfinityConnection连接池
     try:
-        from rag.utils.infinity_conn import InfinityConnection
-        infinity_conn = InfinityConnection()
-        infinity_conn.reinit_connection_pool()
+        conn = InfinityConnection()
+        conn.reinit_connection_pool()
+        settings.docStoreConn = conn
+        settings.retrievaler = search.Dealer(conn)
+        settings.kg_retrievaler = kg_search.KGSearch(conn)
         server.log.info("Successfully reinitialized InfinityConnection in worker %s", worker.pid)
     except Exception as e:
         server.log.error("Failed to reinitialize InfinityConnection in worker %s: %s", worker.pid, str(e))
+
 
 def worker_abort(worker):
     """Called when a worker received the SIGABRT signal."""

--- a/docs/production_deployment_zh.md
+++ b/docs/production_deployment_zh.md
@@ -77,6 +77,7 @@ python api/ragflow_server.py
 - `timeout`: 120秒超时
 - `max_requests`: 1000请求后重启worker
 - `preload_app`: 预加载应用提升性能
+- 如果使用 Infinity 作为文档引擎，需在 `post_fork` 阶段为每个 worker 重新初始化 `InfinityConnection` 连接池，`conf/gunicorn.conf.py` 已实现此逻辑
 
 ### 性能调优
 
@@ -118,7 +119,7 @@ A: 设置环境变量 `GUNICORN_WORKERS` 或修改配置文件中的 `workers` �
 
 ### Q: 开发模式和生产模式的区别？
 
-A: 
+A:
 - 开发模式：使用Werkzeug开发服务器，单进程，有调试功能
 - 生产模式：使用Gunicorn WSGI服务器，多进程，优化性能和稳定性
 
@@ -150,4 +151,4 @@ A: 直接运行 `python api/ragflow_server.py`，但不推荐在生产环境使�
 3. 优化数据库连接
 4. 监控网络延迟
 
-更多问题请参考项目文档或提交Issue。 
+更多问题请参考项目文档或提交Issue。


### PR DESCRIPTION
## Summary
- reinitialize InfinityConnection for each Gunicorn worker
- document Infinity connection pool requirement in the production deployment guide
- mention Infinity+Gunicorn note in README and Chinese README

## Testing
- `pre-commit run --files conf/gunicorn.conf.py docs/production_deployment_zh.md README.md README_zh.md`
- `GUNICORN_WORKERS=2 DOC_ENGINE=infinity bash -c 'echo attempting to run tests; docker compose -f docker/docker-compose.yml up -d'` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fba02d9e483248369daa2db9f9813