### PR TITLE
Fix Infinity connection per Gunicorn worker

### DIFF
--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -91,9 +91,11 @@ def post_fork(server, worker):
                         except Exception as exc:  # pragma: no cover - best effort cleanup
                             worker.log.warning("Failed to close connection pool: %s", exc)
 
-        settings.docStoreConn = __import__("rag.utils.infinity_conn", fromlist=["InfinityConnection"]).InfinityConnection()
+        # Initialize settings again so retrievalers use the new connection
+        if os.environ.get("DOC_ENGINE", settings.DOC_ENGINE).lower() == "infinity":
+            settings.init_settings()
     except Exception as exc:  # pragma: no cover - unexpected errors
-        worker.log.error("Failed to reinitialize InfinityConnection: %s", exc)
+        worker.log.error("Failed to reinitialize settings after fork: %s", exc)
 
 
 def worker_abort(worker):
@@ -124,5 +126,7 @@ def worker_exit(server, worker):
                         except Exception as exc:  # pragma: no cover - best effort cleanup
                             worker.log.warning("Failed to close connection pool: %s", exc)
             settings.docStoreConn = None
+            settings.retrievaler = None
+            settings.kg_retrievaler = None
     except Exception as exc:  # pragma: no cover - unexpected errors
         worker.log.error("Cleanup on worker exit failed: %s", exc)


### PR DESCRIPTION
## Summary
- ensure each Gunicorn worker fully reinitializes RAGFlow settings
- clean up retrieval resources on worker exit

## Testing
- `pytest -k 'this_does_not_exist'` *(fails: ImportError: cannot import name 'add_chunk' from 'common')*

------
https://chatgpt.com/codex/tasks/task_e_683fc352a4fc8324a28dfd623241dabe