### PR TITLE
Fix Infinity multi-worker issue by disabling preload

### DIFF
--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -17,7 +17,7 @@ keepalive = 10
 max_requests = 20000
 max_requests_jitter = 100
 
-preload_app = True
+preload_app = False
 
 # Logging
 accesslog = "-"
@@ -91,9 +91,11 @@ def post_fork(server, worker):
                         except Exception as exc:  # pragma: no cover - best effort cleanup
                             worker.log.warning("Failed to close connection pool: %s", exc)
 
-        settings.docStoreConn = __import__("rag.utils.infinity_conn", fromlist=["InfinityConnection"]).InfinityConnection()
+        # Initialize settings again so retrievalers use the new connection
+        if os.environ.get("DOC_ENGINE", settings.DOC_ENGINE).lower() == "infinity":
+            settings.init_settings()
     except Exception as exc:  # pragma: no cover - unexpected errors
-        worker.log.error("Failed to reinitialize InfinityConnection: %s", exc)
+        worker.log.error("Failed to reinitialize settings after fork: %s", exc)
 
 
 def worker_abort(worker):
@@ -124,5 +126,7 @@ def worker_exit(server, worker):
                         except Exception as exc:  # pragma: no cover - best effort cleanup
                             worker.log.warning("Failed to close connection pool: %s", exc)
             settings.docStoreConn = None
+            settings.retrievaler = None
+            settings.kg_retrievaler = None
     except Exception as exc:  # pragma: no cover - unexpected errors
         worker.log.error("Cleanup on worker exit failed: %s", exc)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -211,7 +211,6 @@ if [[ "${ENABLE_WEBSERVER}" -eq 1 ]]; then
                        --max-requests-jitter 100 \
                        --timeout ${GUNICORN_TIMEOUT} \
                        --keep-alive 2 \
-                       --preload \
                        --bind ${RAGFLOW_HOST}:${RAGFLOW_PORT} \
                        --access-logfile - \
                        --error-logfile - \

--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -98,7 +98,7 @@ run_server(){
     # Defaults are provided if they are not set.
     gunicorn --workers ${GUNICORN_WORKERS:-4} \
              --bind ${RAGFLOW_HOST_IP:-0.0.0.0}:${RAGFLOW_HOST_PORT:-9380} \
-             --preload 'api.apps:app'
+             'api.apps:app'
     EXIT_CODE=$?
     if [ $EXIT_CODE -ne 0 ]; then
         echo "Gunicorn failed with exit code $EXIT_CODE. Exiting..." >&2

--- a/docs/production_deployment_zh.md
+++ b/docs/production_deployment_zh.md
@@ -48,7 +48,7 @@ pip install -r requirements.txt
 gunicorn --config conf/gunicorn.conf.py api.wsgi:application
 
 # 或者使用命令行参数
-gunicorn --workers 4 --bind 0.0.0.0:9380 --preload api.wsgi:application
+gunicorn --workers 4 --bind 0.0.0.0:9380 api.wsgi:application
 ```
 
 ### 方式二：使用配置文件
@@ -76,7 +76,8 @@ python api/ragflow_server.py
 - `worker_class`: 同步工作模式
 - `timeout`: 120秒超时
 - `max_requests`: 1000请求后重启worker
-- `preload_app`: 预加载应用提升性能
+- `preload_app`: 预加载应用可提升性能，但若 `DOC_ENGINE` 设为 `infinity` 且
+  Gunicorn `workers` 大于 1，需关闭此项以避免会话失效问题
 
 ### 性能调优
 


### PR DESCRIPTION
## Summary
- disable gunicorn application preload
- drop `--preload` from Docker helpers
- document disabling preload when running with Infinity

## Testing
- `pytest -k 'this_does_not_exist'` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_683fc352a4fc8324a28dfd623241dabe