### PR TITLE
Serialize table creation across workers

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -416,6 +416,7 @@ class DataBaseModel(BaseModel):
         database = DB
 
 
+@DB.lock("init_database_tables", 60)
 @DB.connection_context()
 def init_database_tables(alter_fields=[]):
     members = inspect.getmembers(sys.modules[__name__], inspect.isclass)
@@ -428,7 +429,7 @@ def init_database_tables(alter_fields=[]):
             if not obj.table_exists():
                 logging.debug(f"start create table {obj.__name__}")
                 try:
-                    obj.create_table()
+                    obj.create_table(safe=True)
                     logging.debug(f"create table success: {obj.__name__}")
                 except Exception as e:
                     logging.exception(e)


### PR DESCRIPTION
## Summary
- prevent duplicate table creation errors by locking the `init_database_tables` function
- ensure tables are created with `IF NOT EXISTS`

## Testing
- `pre-commit run --files api/db/db_models.py`
- `pytest -q` *(fails: ImportError: cannot import name 'add_chunk' from 'common')*

------
https://chatgpt.com/codex/tasks/task_e_683fea565c1c8324b62f24efe798b1ec